### PR TITLE
Fix base path for new repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ZarpadoFit",
   "private": true,
   "version": "0.0.0",
-  "homepage": "https://github.com/AdanUade/ZarpadoFit",
+  "homepage": "https://adanuade.github.io/ZarpadoFit/",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/404.html
+++ b/public/404.html
@@ -4,6 +4,6 @@
     <script>
       sessionStorage.redirect = location.pathname;
     </script>
-    <meta http-equiv="refresh" content="0;URL='/Zarpado-Fit'">
+    <meta http-equiv="refresh" content="0;URL='/ZarpadoFit'">
   </head>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter basename="/Zarpado-Fit">
+    <BrowserRouter basename="/ZarpadoFit">
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- update BrowserRouter basename to `/ZarpadoFit`
- fix redirect in `404.html`
- update `homepage` url

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fc932123c832283edcc301ee38462